### PR TITLE
Add searchToken property to BigCommerceXOConfig

### DIFF
--- a/src/Components/Data/WithBigCommerceConfiguration.tsx
+++ b/src/Components/Data/WithBigCommerceConfiguration.tsx
@@ -21,6 +21,7 @@ export type BigCommerceXOConfig = {
     sortOrder: number;
   }[];
   customFacetConfigurations?: CustomFacet[];
+  searchToken?: string;
 };
 
 export type BigCommerceConfigurationProps = {


### PR DESCRIPTION
Resolve Property 'searchToken' does not exist on type 'BigCommerceXOConfig' error, resolved by adding searchToken property to BigCommerceXOConfig.

![Screenshot 2022-01-27 at 19 36 38](https://user-images.githubusercontent.com/8895777/151431339-7003ecaf-3e43-414b-9569-a1c42c7532ee.png)

