### PR TITLE
Ensure DataList is updated on facet changes

### DIFF
--- a/src/Components/UI/Basic/Facet/FacetDataList.tsx
+++ b/src/Components/UI/Basic/Facet/FacetDataList.tsx
@@ -13,7 +13,7 @@ const FacetDataList = (props: FacetProps) => {
     if (!searchTerm) {
       setValues(props.availableValues || []);
     }
-  }, []);
+  }, [props.availableValues]);
 
   useEffect(() => {
     setValues(


### PR DESCRIPTION
The `DataList` component never updates on the frontend as the `setValues` function is wrapped in a `useEffect` hook with no dependences (empty array as the second argument), this results in the state being set when the component is first initialized but then it never updates again. This results in the DataList facet showing out of date information such as when another facet is applied.

Recording from before this change:

https://user-images.githubusercontent.com/8895777/156802324-86132e6b-7e81-41da-9dc2-3f07b9980ad8.mp4



This change adds `props.availableValues` as a dependency to that hook so when `props.availableValues` changes so does the state which updates the frontend.

Recording from after this change:

https://user-images.githubusercontent.com/8895777/156802360-20664fe2-3747-4157-a56e-e2c0b9a9c2db.mp4


