### PR TITLE
Update DataList values even when search active

### DIFF
--- a/src/Components/UI/Basic/Facet/FacetDataList.tsx
+++ b/src/Components/UI/Basic/Facet/FacetDataList.tsx
@@ -26,7 +26,7 @@ const FacetDataList = (props: FacetProps) => {
         return true;
       }) || []
     );
-  }, [searchTerm]);
+  }, [searchTerm, props.availableValues]);
 
   return (
     <div className="xo__facet xo__facet__data-list">


### PR DESCRIPTION
There is a bug where the DataList values do not update when the user interacts with another facet AND there is an active search term:

https://user-images.githubusercontent.com/8895777/156804395-30ec669d-ab0f-4cbf-b3a7-dcac13c3d0bf.mp4


This change ensures that the values always update when another facet is updated, even if a search term is active:

https://user-images.githubusercontent.com/8895777/156804802-63bdc47a-580c-4557-9ab7-d69fd99ab201.mp4


